### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -35,9 +35,9 @@ func protoUserToResource(proto *identityv1.User) (*v2.Resource, error) {
 
 	user, err := rs.NewUserResource(proto.GetSpec().GetEmail(), userResourceType, proto.GetId(), []rs.UserTraitOption{
 		rs.WithEmail(proto.GetSpec().GetEmail(), true),
-		rs.WithCreatedAt(proto.GetCreatedTime().AsTime()),
 		rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_HUMAN),
-	}, rs.WithAnnotation(annos))
+	},
+		rs.WithResourceCreatedAt(proto.GetCreatedTime().AsTime()), rs.WithAnnotation(annos))
 	if err != nil {
 		return nil, err
 	}
@@ -54,9 +54,9 @@ func protoServiceAccountToResource(proto *identityv1.ServiceAccount) (*v2.Resour
 	}
 
 	sa, err := rs.NewUserResource(name, serviceAccountResourceType, proto.GetId(), []rs.UserTraitOption{
-		rs.WithCreatedAt(proto.GetCreatedTime().AsTime()),
 		rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_SERVICE),
-	})
+	},
+		rs.WithResourceCreatedAt(proto.GetCreatedTime().AsTime()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
